### PR TITLE
Remove leading 'x' from repository name

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Exercism exercises in the D Programming Language
 
-[![Build Status](https://travis-ci.org/exercism/xdlang.svg?branch=master)](https://travis-ci.org/exercism/xdlang)
+[![Build Status](https://travis-ci.org/exercism/dlang.svg?branch=master)](https://travis-ci.org/exercism/dlang)
 
 ## Filenames
 

--- a/config.json
+++ b/config.json
@@ -1,7 +1,7 @@
 {
   "slug": "dlang",
   "language": "D",
-  "repository": "https://github.com/exercism/xdlang",
+  "repository": "https://github.com/exercism/dlang",
   "checklist_issue": 6,
   "active": true,
   "exercises": [


### PR DESCRIPTION
The leading 'x' is kind of arbitrary. Especially now that we can set
topics on the repositories, we don't need a pattern to distinguish what
is a track or not.

The repository itself has already been renamed. GitHub redirects from
the old name to the new name, so we do not have to rush to fix links to
the old repository name, though we should update them for the sake of
clarity.

See exercism/meta#1