### PR TITLE
use specific imports of assertThrown, adding them where missing

### DIFF
--- a/exercises/circular-buffer/example/circular_buffer.d
+++ b/exercises/circular-buffer/example/circular_buffer.d
@@ -1,7 +1,6 @@
 
 module circular;
 
-import std.exception;
 import std.stdio;
 import std.string;
 
@@ -90,6 +89,7 @@ private:
 
 unittest
 {
+import std.exception : assertThrown;
 
 // test read empty buffer
 {

--- a/exercises/circular-buffer/source/circular_buffer.d
+++ b/exercises/circular-buffer/source/circular_buffer.d
@@ -1,10 +1,10 @@
 
 module circular;
 
-import std.exception;
-
 unittest
 {
+import std.exception : assertThrown;
+
 immutable int allTestsEnabled = 0;
 
 // test read empty buffer

--- a/exercises/etl/example/etl.d
+++ b/exercises/etl/example/etl.d
@@ -1,7 +1,6 @@
 
 module etl;
 
-import std.exception;
 import std.string;
 import std.ascii : isUpper, isAlpha, toLower;
 import std.algorithm.searching : countUntil;
@@ -79,6 +78,8 @@ bool aaEqual (const int[dchar] lhs, const int[dchar] rhs)
 
 // throw exception
 {
+	import std.exception : assertThrown;
+
 	immutable string[int] old = [1: "ae"];
 
 	assertThrown(transform(old));

--- a/exercises/hamming/example/hamming.d
+++ b/exercises/hamming/example/hamming.d
@@ -4,7 +4,6 @@ module hamming;
 
 import std.string;
 import std.algorithm.comparison : mismatch;
-import std.exception;
 
 int distance (string lhs, string rhs)
 {
@@ -27,6 +26,8 @@ int distance (string lhs, string rhs)
 
 unittest
 {
+    import std.exception : assertThrown;
+
     assert(distance("A", "A") == 0);
     assert(distance("A", "G") == 1);
     assert(distance("AG", "CT") == 2);

--- a/exercises/hamming/source/hamming.d
+++ b/exercises/hamming/source/hamming.d
@@ -3,6 +3,8 @@ module hamming;
 
 unittest
 {
+import std.exception : assertThrown;
+
 const int allTestsEnabled = 0;
 
     assert(distance("A", "A") == 0);

--- a/exercises/nucleotide-count/example/nucleotide_count.d
+++ b/exercises/nucleotide-count/example/nucleotide_count.d
@@ -7,7 +7,6 @@ import std.algorithm.sorting : sort;
 import std.algorithm.searching : count;
 import std.typecons;
 import std.array : array;
-import std.exception;
 
 
 class Counter
@@ -129,6 +128,8 @@ bool aaEqual (const ulong[char] lhs, const ulong[char] rhs)
 
 // validates_nucleotides
 {
+	import std.exception : assertThrown;
+
 	const Counter dna = new Counter("GGTTGG");
 
 	assertThrown(dna.countOne('X'));

--- a/exercises/nucleotide-count/source/nucleotide_count.d
+++ b/exercises/nucleotide-count/source/nucleotide_count.d
@@ -77,6 +77,8 @@ static if (allTestsEnabled)
 
 // validates_nucleotides
 {
+	import std.exception : assertThrown;
+
 	const Counter dna = new Counter("GGTTGG");
 
 	assertThrown(dna.countOne('X'));

--- a/exercises/rna-transcription/example/rna_transcription.d
+++ b/exercises/rna-transcription/example/rna_transcription.d
@@ -1,6 +1,5 @@
 module rna_transcription;
 
-import std.exception;
 import std.regex;
 import std.string;
 
@@ -17,11 +16,15 @@ static this() {
 enum dnaRegex = regex(r"^[CGTA]*$");
 
 string dnaComplement(string dna) {
+    import std.exception : enforce;
+
     enforce(dna.matchFirst(dnaRegex), "Invalid DNA string");
     return dna.translate(rnaTransTable);
 }
 
 unittest {
+    import std.exception : assertThrown;
+
     assert(dnaComplement("C") == "G");
     assert(dnaComplement("G") == "C");
     assert(dnaComplement("T") == "A");

--- a/exercises/rna-transcription/source/rna_transcription.d
+++ b/exercises/rna-transcription/source/rna_transcription.d
@@ -1,8 +1,8 @@
 module rna_transcription;
 
+unittest {
 import std.exception : assertThrown;
 
-unittest {
 const int allTestsEnabled = 0;
 
     assert(dnaComplement("C") == "G");

--- a/exercises/series/example/series.d
+++ b/exercises/series/example/series.d
@@ -1,7 +1,6 @@
 
 module series;
 
-import std.exception;
 import std.algorithm : equal;
 import std.ascii : isDigit;
 import std.string;
@@ -79,6 +78,7 @@ int[][] slice (string input, uint stride = 1)
 
 unittest
 {
+import std.exception : assertThrown;
 
 // short_digits
 {

--- a/exercises/series/source/series.d
+++ b/exercises/series/source/series.d
@@ -1,11 +1,11 @@
 
 module series;
 
-import std.exception;
 import std.algorithm.comparison : equal;
 
 unittest
 {
+import std.exception : assertThrown;
 
 immutable int allTestsEnabled = 0;
 

--- a/exercises/triangle/example/triangle.d
+++ b/exercises/triangle/example/triangle.d
@@ -1,8 +1,6 @@
 
 module triangle;
 
-import std.exception;
-
 enum TriangleType { equilateral, isosceles, scalene };
 
 /**
@@ -23,6 +21,7 @@ TriangleType kind (double a, double b, double c)
 
 unittest
 {
+import std.exception : assertThrown;
 
 // equilateral_triangles_have_equal_sides
 {

--- a/exercises/triangle/source/triangle.d
+++ b/exercises/triangle/source/triangle.d
@@ -1,11 +1,9 @@
 
 module triangle;
 
-import std.exception;
-
-
 unittest
 {
+import std.exception : assertThrown;
 
 immutable int allTestsEnabled = 0;
 


### PR DESCRIPTION
The D style guide at https://dlang.org/dstyle.html says to prefer local
selective imports.

The indentation is inconsistent here, but I'm not sure there is much I
can do without making the files look inconsistent. I took the rule of
"use indentation level of next line".